### PR TITLE
Add a sensible default for case_call

### DIFF
--- a/default/courtroom_sounds.ini
+++ b/default/courtroom_sounds.ini
@@ -6,3 +6,4 @@ word_call = sfx-bling2
 mod_call = sfx-gallery
 not_guilty = sfx-notguilty
 guilty = sfx-guilty
+case_call = sfx-evidenceadd


### PR DESCRIPTION
Without one, the client will not make a sound when a case alert is triggered.