### PR TITLE
Add slide tickbox to the AOHD themes

### DIFF
--- a/AOHD/courtroom_design.ini
+++ b/AOHD/courtroom_design.ini
@@ -91,8 +91,8 @@ additive = 498, 684, 60, 21
 showname_enable = 566, 684, 78, 21
 pre = 652, 684, 59, 21
 pre_no_interrupt = 719, 684, 70, 21
-casing = 795, 684, 53, 21
-guard = 857, 684, 61, 21
+slide_enable = 795, 684, 80, 21
+guard = 884, 684, 61, 21
 
 
 ; The scrolling music name display

--- a/AOHDDark/courtroom_design.ini
+++ b/AOHDDark/courtroom_design.ini
@@ -91,8 +91,8 @@ additive = 498, 684, 60, 21
 showname_enable = 566, 684, 78, 21
 pre = 652, 684, 59, 21
 pre_no_interrupt = 719, 684, 70, 21
-casing = 795, 684, 53, 21
-guard = 857, 684, 61, 21
+slide_enable = 795, 684, 80, 21
+guard = 884, 684, 61, 21
 
 
 ; The scrolling music name display

--- a/AOHDMini/courtroom_design.ini
+++ b/AOHDMini/courtroom_design.ini
@@ -87,8 +87,8 @@ additive = 342, 684, 60, 21
 showname_enable = 405, 684, 78, 21
 pre = 486, 684, 59, 21
 pre_no_interrupt = 550, 684, 80, 21
-casing = 633, 684, 53, 21
-guard = 689, 684, 61, 21
+slide_enable = 633, 684, 80, 21
+guard = 716, 684, 61, 21
 
 
 ; The scrolling music name display

--- a/AOHDMiniDark/courtroom_design.ini
+++ b/AOHDMiniDark/courtroom_design.ini
@@ -87,8 +87,8 @@ additive = 342, 684, 60, 21
 showname_enable = 405, 684, 78, 21
 pre = 486, 684, 59, 21
 pre_no_interrupt = 550, 684, 80, 21
-casing = 633, 684, 53, 21
-guard = 689, 684, 61, 21
+slide_enable = 633, 684, 80, 21
+guard = 716, 684, 61, 21
 
 
 ; The scrolling music name display

--- a/AOHDUltra/courtroom_design.ini
+++ b/AOHDUltra/courtroom_design.ini
@@ -90,8 +90,8 @@ additive = 504, 960, 60, 21
 showname_enable = 580, 960, 78, 21
 pre = 666, 960, 59, 21
 pre_no_interrupt = 733, 960, 80, 21
-casing = 821, 960, 53, 21
-guard = 882, 960, 81, 21
+slide_enable = 821, 960, 53, 21
+guard = 909, 960, 81, 21
 
 
 ; The scrolling music name display

--- a/AOHDUltraDark/courtroom_design.ini
+++ b/AOHDUltraDark/courtroom_design.ini
@@ -93,8 +93,8 @@ additive = 504, 960, 60, 21
 showname_enable = 580, 960, 78, 21
 pre = 666, 960, 59, 21
 pre_no_interrupt = 733, 960, 80, 21
-casing = 821, 960, 53, 21
-guard = 882, 960, 81, 21
+slide_enable = 821, 960, 53, 21
+guard = 909, 960, 81, 21
 
 
 ; The scrolling music name display

--- a/AceAttorney/courtroom_design.ini
+++ b/AceAttorney/courtroom_design.ini
@@ -164,6 +164,9 @@ ao2_ic_chat_name = 200, 444, 78, 23
 ; character.
 showname_enable = 200, 420, 80, 21
 
+; For enabling slide animations
+slide_enable = 200, 464, 80, 21
+
 ; A simple button that opens up the settings menu.
 ; Equivalent to typing /settings in the OOC chat.
 settings = 130, 520, 60, 23


### PR DESCRIPTION
Adds slide_enable to the AOHD themes +1, put in place of the defunct "casing" tickbox.